### PR TITLE
Implement defrag support for `IValue`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A more memory efficient replacement for serde_json::Value"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["thread_safe"]
+default = []
 tracing = ["mockalloc/tracing"]
 thread_safe = []
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -369,7 +369,10 @@ impl<A: DefragAllocator> Defrag<A> for IArray {
             }
         }
         unsafe {
-            let new_ptr = defrag_allocator.realloc_ptr(self.0.ptr(), Self::layout((*self.0.ptr().cast::<Header>()).cap).unwrap());
+            let new_ptr = defrag_allocator.realloc_ptr(
+                self.0.ptr(),
+                Self::layout((*self.0.ptr().cast::<Header>()).cap).unwrap(),
+            );
             self.0.set_ptr(new_ptr.cast());
         }
         self

--- a/src/array.rs
+++ b/src/array.rs
@@ -371,7 +371,8 @@ impl<A: DefragAllocator> Defrag<A> for IArray {
         unsafe {
             let new_ptr = defrag_allocator.realloc_ptr(
                 self.0.ptr(),
-                Self::layout((*self.0.ptr().cast::<Header>()).cap).unwrap(),
+                Self::layout((*self.0.ptr().cast::<Header>()).cap)
+                    .expect("layout is expected to return a valid value"),
             );
             self.0.set_ptr(new_ptr.cast());
         }

--- a/src/array.rs
+++ b/src/array.rs
@@ -10,6 +10,7 @@ use std::ops::{Deref, DerefMut, Index, IndexMut};
 use std::slice::SliceIndex;
 
 use crate::thin::{ThinMut, ThinMutExt, ThinRef, ThinRefExt};
+use crate::{Defrag, DefragAllocator};
 
 use super::value::{IValue, TypeTag};
 
@@ -196,6 +197,7 @@ impl IArray {
             unsafe { self.header_mut().items_slice_mut() }
         }
     }
+
     fn resize_internal(&mut self, cap: usize) {
         if self.is_static() || cap == 0 {
             *self = Self::with_capacity(cap);
@@ -351,6 +353,26 @@ impl IArray {
                 self.0.set_ref(&EMPTY_HEADER);
             }
         }
+    }
+}
+
+impl<A: DefragAllocator> Defrag<A> for IArray {
+    fn defrag(mut self, defrag_allocator: &mut A) -> Self {
+        if self.is_static() {
+            return self;
+        }
+        for i in 0..self.len() {
+            unsafe {
+                let val = self.as_ptr().add(i).read();
+                let val = val.defrag(defrag_allocator);
+                std::ptr::write(self.as_ptr().add(i) as *mut IValue, val);
+            }
+        }
+        unsafe {
+            let new_ptr = defrag_allocator.realloc_ptr(self.0.ptr(), Self::layout((*self.0.ptr().cast::<Header>()).cap).unwrap());
+            self.0.set_ptr(new_ptr.cast());
+        }
+        self
     }
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -8,6 +8,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 
 use crate::thin::{ThinMut, ThinMutExt, ThinRef, ThinRefExt};
+use crate::{Defrag, DefragAllocator};
 
 use super::value::{IValue, TypeTag};
 
@@ -707,6 +708,20 @@ impl Debug for INumber {
 impl Default for INumber {
     fn default() -> Self {
         Self::zero()
+    }
+}
+
+impl<A: DefragAllocator> Defrag<A> for INumber {
+    fn defrag(mut self, defrag_allocator: &mut A) -> Self {
+        let hd = self.header();
+        if hd.type_ == NumberType::Static {
+            return self;
+        }
+        unsafe {
+            let ptr = self.0.ptr().cast::<Header>();
+            self.0.set_ptr(defrag_allocator.realloc_ptr(ptr.cast(), Self::layout((*ptr).type_).unwrap()))
+        };
+        self
     }
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -719,7 +719,9 @@ impl<A: DefragAllocator> Defrag<A> for INumber {
         }
         unsafe {
             let ptr = self.0.ptr().cast::<Header>();
-            self.0.set_ptr(defrag_allocator.realloc_ptr(ptr.cast(), Self::layout((*ptr).type_).unwrap()))
+            self.0.set_ptr(
+                defrag_allocator.realloc_ptr(ptr.cast(), Self::layout((*ptr).type_).unwrap()),
+            )
         };
         self
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -1085,14 +1085,14 @@ impl<A: DefragAllocator> Defrag<A> for IObject {
             return self;
         }
         let header = unsafe { self.header_mut() };
-        let slit_header = header.split_mut();
-        for i in 0..slit_header.items.len() {
+        let split_header = header.split_mut();
+        for i in 0..split_header.items.len() {
             unsafe {
-                let old_val = slit_header.items.as_ptr().add(i).read();
+                let old_val = split_header.items.as_ptr().add(i).read();
                 let value = old_val.value.defrag(defrag_allocator);
                 let key = old_val.key.defrag(defrag_allocator);
                 std::ptr::write(
-                    slit_header.items.as_ptr().add(i) as *mut KeyValuePair,
+                    split_header.items.as_ptr().add(i) as *mut KeyValuePair,
                     KeyValuePair { key, value },
                 );
             }

--- a/src/object.rs
+++ b/src/object.rs
@@ -1084,14 +1084,17 @@ impl<A: DefragAllocator> Defrag<A> for IObject {
         if self.is_static() {
             return self;
         }
-        let header = unsafe{self.header_mut()};
+        let header = unsafe { self.header_mut() };
         let slit_header = header.split_mut();
         for i in 0..slit_header.items.len() {
-            unsafe{
+            unsafe {
                 let old_val = slit_header.items.as_ptr().add(i).read();
                 let value = old_val.value.defrag(defrag_allocator);
                 let key = old_val.key.defrag(defrag_allocator);
-                std::ptr::write(slit_header.items.as_ptr().add(i) as *mut KeyValuePair, KeyValuePair{key, value});
+                std::ptr::write(
+                    slit_header.items.as_ptr().add(i) as *mut KeyValuePair,
+                    KeyValuePair { key, value },
+                );
             }
         }
         unsafe {

--- a/src/object.rs
+++ b/src/object.rs
@@ -11,6 +11,7 @@ use std::mem;
 use std::ops::{Index, IndexMut};
 
 use crate::thin::{ThinMut, ThinMutExt, ThinRef, ThinRefExt};
+use crate::{Defrag, DefragAllocator};
 
 #[cfg(feature = "thread_safe")]
 use super::string::IString;
@@ -38,12 +39,9 @@ fn hash_capacity(cap: usize) -> usize {
 }
 
 fn hash_fn(s: &IString) -> usize {
-    let v: &IValue = s.as_ref();
-    // We know the bottom two bits are always the same
-    let mut p = v.ptr_usize() >> 2;
-    p = p.wrapping_mul(202_529);
-    p = p ^ (p >> 13);
-    p.wrapping_mul(202_529)
+    let mut hasher = DefaultHasher::new();
+    s.as_str().hash(&mut hasher);
+    hasher.finish() as usize
 }
 
 fn hash_bucket(s: &IString, hash_cap: usize) -> usize {
@@ -1078,6 +1076,30 @@ impl<K: Into<IString>, V: Into<IValue>> From<BTreeMap<K, V>> for IObject {
 impl Default for IObject {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<A: DefragAllocator> Defrag<A> for IObject {
+    fn defrag(mut self, defrag_allocator: &mut A) -> Self {
+        if self.is_static() {
+            return self;
+        }
+        let header = unsafe{self.header_mut()};
+        let slit_header = header.split_mut();
+        for i in 0..slit_header.items.len() {
+            unsafe{
+                let old_val = slit_header.items.as_ptr().add(i).read();
+                let value = old_val.value.defrag(defrag_allocator);
+                let key = old_val.key.defrag(defrag_allocator);
+                std::ptr::write(slit_header.items.as_ptr().add(i) as *mut KeyValuePair, KeyValuePair{key, value});
+            }
+        }
+        unsafe {
+            let ptr = self.0.ptr().cast::<Header>();
+            let new_ptr = defrag_allocator.realloc_ptr(ptr, Self::layout((*ptr).cap).unwrap());
+            self.0.set_ptr(new_ptr.cast());
+        }
+        self
     }
 }
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -13,6 +13,7 @@ use dashmap::{DashSet, SharedValue};
 use lazy_static::lazy_static;
 
 use crate::thin::{ThinMut, ThinMutExt, ThinRef, ThinRefExt};
+use crate::{Defrag, DefragAllocator};
 
 use super::value::{IValue, TypeTag};
 
@@ -400,6 +401,12 @@ impl Hash for IString {
 impl Debug for IString {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl<A: DefragAllocator> Defrag<A> for IString {
+    fn defrag(self, _defrag_allocator: &mut A) -> Self {
+        self
     }
 }
 

--- a/src/unsafe_string.rs
+++ b/src/unsafe_string.rs
@@ -6,10 +6,12 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
+use std::mem;
 use std::ops::Deref;
 use std::ptr::{copy_nonoverlapping, NonNull};
 
 use crate::thin::{ThinMut, ThinMutExt, ThinRef, ThinRefExt};
+use crate::{Defrag, DefragAllocator};
 
 use super::value::{IValue, TypeTag};
 
@@ -68,6 +70,12 @@ pub fn init_cache() {
         if STRING_CACHE.is_none() {
             STRING_CACHE = Some(HashSet::new());
         };
+    }
+}
+
+pub(crate) fn reinit_cache() {
+    unsafe {
+        STRING_CACHE = Some(HashSet::new());
     }
 }
 
@@ -160,10 +168,10 @@ impl IString {
             .pad_to_align())
     }
 
-    fn alloc(s: &str) -> *mut Header {
+    fn alloc<A: FnMut(Layout) -> *mut u8>(s: &str, mut allocator: A) -> *mut Header {
         assert!((s.len() as u64) < (1 << 48));
         unsafe {
-            let ptr = alloc(Self::layout(s.len()).unwrap()).cast::<Header>();
+            let ptr = allocator(Self::layout(s.len()).unwrap()).cast::<Header>();
             ptr.write(Header {
                 len_lower: s.len() as u32,
                 len_upper: ((s.len() as u64) >> 32) as u16,
@@ -175,29 +183,32 @@ impl IString {
         }
     }
 
-    fn dealloc(ptr: *mut Header) {
+    fn dealloc<D: FnMut(*mut u8, Layout)>(ptr: *mut Header, mut deallocator: D) {
         unsafe {
             let hd = ThinRef::new(ptr);
             let layout = Self::layout(hd.len()).unwrap();
-            dealloc(ptr.cast::<u8>(), layout);
+            deallocator(ptr.cast::<u8>(), layout);
         }
+    }
+
+    fn intern_with_allocator<A: FnMut(Layout) -> *mut u8>(s: &str, allocator: A) -> Self {
+        if s.is_empty() {
+            return Self::new();
+        }
+
+        
+        let cache = unsafe { get_cache() };
+
+        let k = cache.get_or_insert_with(s, |s| WeakIString {
+            ptr: unsafe{ NonNull::new_unchecked(Self::alloc(s, allocator)) },
+        });
+        k.upgrade()
     }
 
     /// Converts a `&str` to an `IString` by interning it in the global string cache.
     #[must_use]
     pub fn intern(s: &str) -> Self {
-        if s.is_empty() {
-            return Self::new();
-        }
-
-        unsafe {
-            let cache = get_cache();
-
-            let k = cache.get_or_insert_with(s, |s| WeakIString {
-                ptr: NonNull::new_unchecked(Self::alloc(s)),
-            });
-            k.upgrade()
-        }
+        Self::intern_with_allocator(s, |layout| unsafe{alloc(layout)})
     }
 
     fn header(&self) -> ThinMut<Header> {
@@ -242,25 +253,35 @@ impl IString {
             unsafe { self.0.raw_copy() }
         }
     }
-    pub(crate) fn drop_impl(&mut self) {
+
+    fn drop_impl_with_deallocator<D: FnMut(*mut u8, Layout)>(&mut self, deallocator: D) {
         if !self.is_empty() {
             let mut hd = self.header();
             hd.rc -= 1;
             if hd.rc == 0 {
                 // Reference count reached zero, free the string
-                unsafe {
-                    let cache = get_cache();
-                    cache.remove(hd.str());
-
-                    // Shrink the cache if it is empty in tests to verify no memory leaks
-                    #[cfg(test)]
-                    if cache.is_empty() {
-                        cache.shrink_to_fit();
+                let cache = unsafe { get_cache() };
+                if let Some(element) = cache.get(hd.str()) {
+                    // we can not simply remove the element from the cache, while we
+                    // perform active defrag, the element might be in the cache but will
+                    // point to another (newer) value. In this case we do not want to remove it.
+                    if element.ptr.as_ptr().cast() == unsafe{ self.0.ptr() } {
+                        cache.remove(hd.str());
                     }
                 }
-                Self::dealloc(unsafe { self.0.ptr().cast() });
+
+                // Shrink the cache if it is empty in tests to verify no memory leaks
+                #[cfg(test)]
+                if cache.is_empty() {
+                    cache.shrink_to_fit();
+                }
+                Self::dealloc(unsafe { self.0.ptr().cast() }, deallocator);
             }
         }
+    }
+
+    pub(crate) fn drop_impl(&mut self) {
+        self.drop_impl_with_deallocator(|ptr, layout| unsafe{ dealloc(ptr, layout) });
     }
 }
 
@@ -315,7 +336,15 @@ impl From<IString> for String {
 
 impl PartialEq for IString {
     fn eq(&self, other: &Self) -> bool {
-        self.0.raw_eq(&other.0)
+        if self.0.raw_eq(&other.0) {
+            // if we have the same exact point we know they are equals.
+            return true;
+        }
+        // otherwise we need to compare the strings.
+        let s1 = self.as_str();
+        let s2 = other.as_str();
+        let res = s1 == s2;
+        res
     }
 }
 
@@ -366,13 +395,22 @@ impl PartialOrd for IString {
 }
 impl Hash for IString {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.raw_hash(state);
+        self.as_str().hash(state)
     }
 }
 
 impl Debug for IString {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl<A: DefragAllocator> Defrag<A> for IString {
+    fn defrag(mut self, defrag_allocator: &mut A) -> Self {
+        let new = Self::intern_with_allocator(self.as_str(), |layout| unsafe{ defrag_allocator.alloc(layout) });
+        self.drop_impl_with_deallocator(|ptr, layout| unsafe{ defrag_allocator.free(ptr, layout) });
+        mem::forget(self);
+        new
     }
 }
 

--- a/src/unsafe_string.rs
+++ b/src/unsafe_string.rs
@@ -196,11 +196,10 @@ impl IString {
             return Self::new();
         }
 
-        
         let cache = unsafe { get_cache() };
 
         let k = cache.get_or_insert_with(s, |s| WeakIString {
-            ptr: unsafe{ NonNull::new_unchecked(Self::alloc(s, allocator)) },
+            ptr: unsafe { NonNull::new_unchecked(Self::alloc(s, allocator)) },
         });
         k.upgrade()
     }
@@ -208,7 +207,7 @@ impl IString {
     /// Converts a `&str` to an `IString` by interning it in the global string cache.
     #[must_use]
     pub fn intern(s: &str) -> Self {
-        Self::intern_with_allocator(s, |layout| unsafe{alloc(layout)})
+        Self::intern_with_allocator(s, |layout| unsafe { alloc(layout) })
     }
 
     fn header(&self) -> ThinMut<Header> {
@@ -265,7 +264,7 @@ impl IString {
                     // we can not simply remove the element from the cache, while we
                     // perform active defrag, the element might be in the cache but will
                     // point to another (newer) value. In this case we do not want to remove it.
-                    if element.ptr.as_ptr().cast() == unsafe{ self.0.ptr() } {
+                    if element.ptr.as_ptr().cast() == unsafe { self.0.ptr() } {
                         cache.remove(hd.str());
                     }
                 }
@@ -281,7 +280,7 @@ impl IString {
     }
 
     pub(crate) fn drop_impl(&mut self) {
-        self.drop_impl_with_deallocator(|ptr, layout| unsafe{ dealloc(ptr, layout) });
+        self.drop_impl_with_deallocator(|ptr, layout| unsafe { dealloc(ptr, layout) });
     }
 }
 
@@ -407,8 +406,12 @@ impl Debug for IString {
 
 impl<A: DefragAllocator> Defrag<A> for IString {
     fn defrag(mut self, defrag_allocator: &mut A) -> Self {
-        let new = Self::intern_with_allocator(self.as_str(), |layout| unsafe{ defrag_allocator.alloc(layout) });
-        self.drop_impl_with_deallocator(|ptr, layout| unsafe{ defrag_allocator.free(ptr, layout) });
+        let new = Self::intern_with_allocator(self.as_str(), |layout| unsafe {
+            defrag_allocator.alloc(layout)
+        });
+        self.drop_impl_with_deallocator(|ptr, layout| unsafe {
+            defrag_allocator.free(ptr, layout)
+        });
         mem::forget(self);
         new
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -211,14 +211,30 @@ unsafe impl Send for IValue {}
 unsafe impl Sync for IValue {}
 
 impl<A: DefragAllocator> Defrag<A> for IValue {
-    fn defrag(self, defrag_allocator: &mut A)-> Self {
+    fn defrag(self, defrag_allocator: &mut A) -> Self {
         match self.type_() {
             // Inline types has nothing to defrag todo: is that true?
-            ValueType::Null | ValueType::Bool => {self}
-            ValueType::Array => unsafe { self.to_array_unchecked() }.defrag(defrag_allocator).0,
-            ValueType::Object => unsafe { self.to_object_unchecked() }.defrag(defrag_allocator).0,
-            ValueType::String => unsafe { self.to_string_unchecked() }.defrag(defrag_allocator).0,
-            ValueType::Number => unsafe { self.to_number_unchecked() }.defrag(defrag_allocator).0,
+            ValueType::Null | ValueType::Bool => self,
+            ValueType::Array => {
+                unsafe { self.to_array_unchecked() }
+                    .defrag(defrag_allocator)
+                    .0
+            }
+            ValueType::Object => {
+                unsafe { self.to_object_unchecked() }
+                    .defrag(defrag_allocator)
+                    .0
+            }
+            ValueType::String => {
+                unsafe { self.to_string_unchecked() }
+                    .defrag(defrag_allocator)
+                    .0
+            }
+            ValueType::Number => {
+                unsafe { self.to_number_unchecked() }
+                    .defrag(defrag_allocator)
+                    .0
+            }
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -212,29 +212,19 @@ unsafe impl Sync for IValue {}
 
 impl<A: DefragAllocator> Defrag<A> for IValue {
     fn defrag(self, defrag_allocator: &mut A) -> Self {
-        match self.type_() {
-            // Inline types has nothing to defrag todo: is that true?
-            ValueType::Null | ValueType::Bool => self,
-            ValueType::Array => {
-                unsafe { self.to_array_unchecked() }
-                    .defrag(defrag_allocator)
-                    .0
+        match self.destructure() {
+            Destructured::Null => IValue::NULL,
+            Destructured::Bool(val) => {
+                if val {
+                    IValue::TRUE
+                } else {
+                    IValue::FALSE
+                }
             }
-            ValueType::Object => {
-                unsafe { self.to_object_unchecked() }
-                    .defrag(defrag_allocator)
-                    .0
-            }
-            ValueType::String => {
-                unsafe { self.to_string_unchecked() }
-                    .defrag(defrag_allocator)
-                    .0
-            }
-            ValueType::Number => {
-                unsafe { self.to_number_unchecked() }
-                    .defrag(defrag_allocator)
-                    .0
-            }
+            Destructured::Array(array) => array.defrag(defrag_allocator).0,
+            Destructured::Object(obj) => obj.defrag(defrag_allocator).0,
+            Destructured::String(s) => s.defrag(defrag_allocator).0,
+            Destructured::Number(n) => n.defrag(defrag_allocator).0,
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -8,6 +8,8 @@ use std::mem;
 use std::ops::{Deref, Index, IndexMut};
 use std::ptr::NonNull;
 
+use crate::{Defrag, DefragAllocator};
+
 use super::array::IArray;
 use super::number::INumber;
 use super::object::IObject;
@@ -207,6 +209,19 @@ pub enum ValueType {
 
 unsafe impl Send for IValue {}
 unsafe impl Sync for IValue {}
+
+impl<A: DefragAllocator> Defrag<A> for IValue {
+    fn defrag(self, defrag_allocator: &mut A)-> Self {
+        match self.type_() {
+            // Inline types has nothing to defrag todo: is that true?
+            ValueType::Null | ValueType::Bool => {self}
+            ValueType::Array => unsafe { self.to_array_unchecked() }.defrag(defrag_allocator).0,
+            ValueType::Object => unsafe { self.to_object_unchecked() }.defrag(defrag_allocator).0,
+            ValueType::String => unsafe { self.to_string_unchecked() }.defrag(defrag_allocator).0,
+            ValueType::Number => unsafe { self.to_number_unchecked() }.defrag(defrag_allocator).0,
+        }
+    }
+}
 
 impl IValue {
     // Safety: Tag must not be `Number`
@@ -608,6 +623,24 @@ impl IValue {
     }
 
     // Safety: Must be an array
+    unsafe fn to_array_unchecked(self) -> IArray {
+        IArray(self)
+    }
+
+    // Safety: Must be an array
+    unsafe fn to_object_unchecked(self) -> IObject {
+        IObject(self)
+    }
+
+    unsafe fn to_string_unchecked(self) -> IString {
+        IString(self)
+    }
+
+    unsafe fn to_number_unchecked(self) -> INumber {
+        INumber(self)
+    }
+
+    // Safety: Must be an array
     unsafe fn as_array_unchecked_mut(&mut self) -> &mut IArray {
         self.unchecked_cast_mut()
     }
@@ -753,7 +786,8 @@ impl PartialEq for IValue {
             unsafe {
                 match t1 {
                     // Inline and interned types can be trivially compared
-                    ValueType::Null | ValueType::Bool | ValueType::String => self.ptr == other.ptr,
+                    ValueType::Null | ValueType::Bool => self.ptr == other.ptr,
+                    ValueType::String => self.as_string_unchecked() == other.as_string_unchecked(),
                     ValueType::Number => self.as_number_unchecked() == other.as_number_unchecked(),
                     ValueType::Array => self.as_array_unchecked() == other.as_array_unchecked(),
                     ValueType::Object => self.as_object_unchecked() == other.as_object_unchecked(),
@@ -1111,5 +1145,98 @@ mod tests {
         let x = IValue::from(o.clone());
 
         assert_eq!(x.into_object(), Ok(o));
+    }
+}
+
+#[cfg(test)]
+mod tests_defrag {
+    use std::alloc::{alloc, dealloc, Layout};
+
+    use super::*;
+
+    struct DummyDefragAllocator;
+
+    impl DefragAllocator for DummyDefragAllocator {
+        unsafe fn realloc_ptr<T>(&mut self, ptr: *mut T, layout: Layout) -> *mut T {
+            let new_ptr = self.alloc(layout).cast::<T>();
+            std::ptr::copy_nonoverlapping(ptr.cast::<u8>(), new_ptr.cast::<u8>(), layout.size());
+            self.free(ptr, layout);
+            new_ptr
+        }
+
+        /// Allocate memory for defrag
+        unsafe fn alloc(&mut self, layout: Layout) -> *mut u8 {
+            alloc(layout)
+        }
+
+        /// Free memory for defrag
+        unsafe fn free<T>(&mut self, ptr: *mut T, layout: Layout) {
+            dealloc(ptr as *mut u8, layout);
+        }
+    }
+
+    fn test_defrag_generic(val: IValue) {
+        let defrag_val = val.clone();
+        crate::reinit_shared_string_cache();
+        let defrag_val = defrag_val.defrag(&mut DummyDefragAllocator);
+        assert_eq!(val, defrag_val);
+    }
+
+    #[test]
+    fn test_defrag_null() {
+        test_defrag_generic(ijson!(null));
+    }
+
+    #[test]
+    fn test_defrag_bool() {
+        test_defrag_generic(ijson!(true));
+        test_defrag_generic(ijson!(false));
+    }
+
+    #[test]
+    fn test_defrag_number() {
+        test_defrag_generic(ijson!(1));
+        test_defrag_generic(ijson!(1000000000));
+        test_defrag_generic(ijson!(-1000000000));
+        test_defrag_generic(ijson!(1.11111111));
+        test_defrag_generic(ijson!(-1.11111111));
+    }
+
+    #[test]
+    fn test_defrag_string() {
+        test_defrag_generic(ijson!("test"));
+        test_defrag_generic(ijson!(""));
+    }
+
+    #[test]
+    fn test_defrag_array() {
+        test_defrag_generic(ijson!([1, 2, "bar"]));
+    }
+
+    #[test]
+    fn test_defrag_array_of_numbers() {
+        test_defrag_generic(ijson!([1, 2, 3]));
+    }
+
+    #[test]
+    fn test_defrag_empty_array_of_numbers() {
+        test_defrag_generic(ijson!([]));
+    }
+
+    #[test]
+    fn test_defrag_object() {
+        test_defrag_generic(ijson!({"foo": "bar"}));
+    }
+
+    #[test]
+    fn test_defrag_empty_object() {
+        test_defrag_generic(ijson!({}));
+    }
+
+    #[test]
+    fn test_defrag_complex() {
+        test_defrag_generic(ijson!([
+            {"foo": "bar"}, 1, 2, 3, null, true, false, {"test":[1,2,null, true, false, 3, {"foo":[1, "bar"]}]}
+        ]));
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -278,9 +278,6 @@ impl IValue {
     pub(crate) fn raw_eq(&self, other: &Self) -> bool {
         self.ptr == other.ptr
     }
-    pub(crate) fn raw_hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.ptr.hash(state);
-    }
     fn is_ptr(&self) -> bool {
         self.ptr_usize() >= ALIGNMENT
     }
@@ -626,24 +623,6 @@ impl IValue {
     // Safety: Must be an array
     unsafe fn as_array_unchecked(&self) -> &IArray {
         self.unchecked_cast_ref()
-    }
-
-    // Safety: Must be an array
-    unsafe fn to_array_unchecked(self) -> IArray {
-        IArray(self)
-    }
-
-    // Safety: Must be an array
-    unsafe fn to_object_unchecked(self) -> IObject {
-        IObject(self)
-    }
-
-    unsafe fn to_string_unchecked(self) -> IString {
-        IString(self)
-    }
-
-    unsafe fn to_number_unchecked(self) -> INumber {
-        INumber(self)
     }
 
     // Safety: Must be an array


### PR DESCRIPTION
The PR adds support for defrag on `IValue`. The defrag uses the provided `DefragAllocator` to reallocate all the memory of the `IValue`.

### Shared String Support

In general, it is considered easy to reallocate all the pointer of the `IValue` the only exception is the shared strings which we can not simply reallocate and free the old pointer because there might be more references that points to it.

To solve this issue we provide a way to clean the shared strings dictionary. This will cause new strings to be allocated from scratch and old shared strings will be freed when there will have no more references.

Notice that this means that now a shared string might not actually be shared between all jsons. Two json might have the same strings but with a different instance. This means that we can no longer count on pointer value for strings hash function, we must perform the hash function on the string value itself.