### PR TITLE
Enable homogenous arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1.0.117"
 serde_json = "1.0.59"
 ctor = { version = "0.1.16", optional = true }
 paste = "1.0.15"
+half = "2.0.0"
 
 [dev-dependencies]
 mockalloc = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1.4.0"
 serde = "1.0.117"
 serde_json = "1.0.59"
 ctor = { version = "0.1.16", optional = true }
+paste = "1.0.15"
 
 [dev-dependencies]
 mockalloc = "0.1.2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/array.rs
+++ b/src/array.rs
@@ -511,7 +511,7 @@ trait HeaderMut<'a>: ThinMutExt<'a, Header> {
                     let array_ptr = self.reborrow().raw_array_ptr_mut().cast::<$tag>();
                     array_ptr.add(index).write(val);
                 } else {
-                    panic!("Cannot push non-{} value to {} array", stringify!($tag), stringify!($tag));
+                    unreachable!("called push_typed! with incompatible type");
                 }
             };
         }
@@ -1223,10 +1223,18 @@ impl Hash for IArray {
             U32(slice) => slice.hash(state),
             I64(slice) => slice.hash(state),
             U64(slice) => slice.hash(state),
-            F16(slice) => slice.iter().map(|f| IValue::from(*f)).collect::<Vec<_>>().hash(state),
-            BF16(slice) => slice.iter().map(|f| IValue::from(*f)).collect::<Vec<_>>().hash(state),
-            F32(slice) => slice.iter().map(|f| IValue::from(*f)).collect::<Vec<_>>().hash(state),
-            F64(slice) => slice.iter().map(|f| IValue::from(*f)).collect::<Vec<_>>().hash(state),
+            F16(slice) => slice.iter().for_each(|f| {
+                f.to_bits().hash(state);
+            }),
+            BF16(slice) => slice.iter().for_each(|f| {
+                f.to_bits().hash(state);
+            }),
+            F32(slice) => slice.iter().for_each(|f| {
+                f.to_bits().hash(state);
+            }),
+            F64(slice) => slice.iter().for_each(|f| {
+                f.to_bits().hash(state);
+            }),
         }
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -2,7 +2,7 @@
 
 use std::alloc::{alloc, dealloc, realloc, Layout, LayoutError};
 use std::borrow::{Borrow, BorrowMut};
-use std::cmp::{self, Ordering};
+use std::cmp::{self, Ordering, PartialOrd};
 use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 use std::iter::FromIterator;
@@ -14,11 +14,283 @@ use crate::{Defrag, DefragAllocator};
 
 use super::value::{IValue, TypeTag};
 
+/// Tag indicating the type of elements stored in a typed array
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ArrayTag {
+    /// Array contains heterogeneous IValue objects
+    Heterogeneous = 0,
+    /// Array contains i8 values
+    I8 = 1,
+    /// Array contains u8 values
+    U8 = 2,
+    /// Array contains i16 values
+    I16 = 3,
+    /// Array contains u16 values
+    U16 = 4,
+    /// Array contains i32 values
+    I32 = 5,
+    /// Array contains u32 values
+    U32 = 6,
+    /// Array contains f32 values
+    F32 = 7,
+    /// Array contains i64 values
+    I64 = 8,
+    /// Array contains u64 values
+    U64 = 9,
+    /// Array contains f64 values
+    F64 = 10,
+}
+
+impl Default for ArrayTag {
+    fn default() -> Self {
+        Self::Heterogeneous
+    }
+}
+
+impl ArrayTag {
+    fn from_type<T>() -> Self {
+        use ArrayTag::*;
+        match std::any::type_name::<T>() {
+            "i8" => I8,
+            "u8" => U8,
+            "i16" => I16,
+            "u16" => U16,
+            "i32" => I32,
+            "u32" => U32,
+            "f32" => F32,
+            "i64" => I64,
+            "u64" => U64,
+            "f64" => F64,
+            _ => Heterogeneous,
+        }
+    }
+}
+
+/// Enum representing different types of array slices that can be returned from typed arrays
+#[derive(Clone, PartialEq)]
+pub enum ArraySliceRef<'a> {
+    /// Heterogeneous array containing IValue objects
+    Heterogeneous(&'a [IValue]),
+    /// Typed array of i8 values
+    I8(&'a [i8]),
+    /// Typed array of u8 values
+    U8(&'a [u8]),
+    /// Typed array of i16 values
+    I16(&'a [i16]),
+    /// Typed array of u16 values
+    U16(&'a [u16]),
+    /// Typed array of i32 values
+    I32(&'a [i32]),
+    /// Typed array of u32 values
+    U32(&'a [u32]),
+    /// Typed array of f32 values
+    F32(&'a [f32]),
+    /// Typed array of i64 values
+    I64(&'a [i64]),
+    /// Typed array of u64 values
+    U64(&'a [u64]),
+    /// Typed array of f64 values
+    F64(&'a [f64]),
+}
+
+impl<'a> ArraySliceRef<'a> {
+    /// Returns the length of the slice regardless of type
+    pub fn len(&self) -> usize {
+        use ArraySliceRef::*;
+        match self {
+            Heterogeneous(slice) => slice.len(),
+            I8(slice) => slice.len(),
+            U8(slice) => slice.len(),
+            I16(slice) => slice.len(),
+            U16(slice) => slice.len(),
+            I32(slice) => slice.len(),
+            U32(slice) => slice.len(),
+            F32(slice) => slice.len(),
+            I64(slice) => slice.len(),
+            U64(slice) => slice.len(),
+            F64(slice) => slice.len(),
+        }
+    }
+
+    /// Returns true if the slice is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the type tag of the array slice
+    pub fn type_tag(&self) -> ArrayTag {
+        use ArrayTag::*;
+        match self {
+            Self::Heterogeneous(_) => Heterogeneous,
+            Self::I8(_) => I8,
+            Self::U8(_) => U8,
+            Self::I16(_) => I16,
+            Self::U16(_) => U16,
+            Self::I32(_) => I32,
+            Self::U32(_) => U32,
+            Self::F32(_) => F32,
+            Self::I64(_) => I64,
+            Self::U64(_) => U64,
+            Self::F64(_) => F64,
+        }
+    }
+
+    /// Returns true if this is a heterogeneous array slice
+    pub fn is_heterogeneous(&self) -> bool {
+        matches!(self, Self::Heterogeneous(_))
+    }
+
+    /// Returns true if this is a typed array slice
+    pub fn is_typed(&self) -> bool {
+        !self.is_heterogeneous()
+    }
+}
+
+impl PartialOrd for ArraySliceRef<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        use ArraySliceRef::*;
+        match (self, other) {
+            (Heterogeneous(a), Heterogeneous(b)) => a.partial_cmp(b),
+            (I8(a), I8(b)) => a.partial_cmp(b),
+            (U8(a), U8(b)) => a.partial_cmp(b),
+            (I16(a), I16(b)) => a.partial_cmp(b),
+            (U16(a), U16(b)) => a.partial_cmp(b),
+            (I32(a), I32(b)) => a.partial_cmp(b),
+            (U32(a), U32(b)) => a.partial_cmp(b),
+            (F32(a), F32(b)) => a.partial_cmp(b),
+            (I64(a), I64(b)) => a.partial_cmp(b),
+            (U64(a), U64(b)) => a.partial_cmp(b),
+            (F64(a), F64(b)) => a.partial_cmp(b),
+            _ => None, // Different types are not comparable
+        }
+    }
+}
+
+macro_rules! from_impl {
+    ($(($ty:ty, $variant:ident)),*) => {
+        $(impl<'a> From<&'a [$ty]> for ArraySliceRef<'a> {
+            fn from(slice: &'a [$ty]) -> Self {
+                ArraySliceRef::$variant(slice)
+            }
+        })*
+    };
+}
+
+from_impl!(
+    (i8, I8),
+    (u8, U8),
+    (i16, I16),
+    (u16, U16),
+    (i32, I32),
+    (u32, U32),
+    (f32, F32),
+    (i64, I64),
+    (u64, U64),
+    (f64, F64),
+    (IValue, Heterogeneous)
+);
+
+impl Debug for ArraySliceRef<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        use ArraySliceRef::*;
+        match self {
+            Heterogeneous(slice) => Debug::fmt(slice, f),
+            I8(slice) => Debug::fmt(slice, f),
+            U8(slice) => Debug::fmt(slice, f),
+            I16(slice) => Debug::fmt(slice, f),
+            U16(slice) => Debug::fmt(slice, f),
+            I32(slice) => Debug::fmt(slice, f),
+            U32(slice) => Debug::fmt(slice, f),
+            F32(slice) => Debug::fmt(slice, f),
+            I64(slice) => Debug::fmt(slice, f),
+            U64(slice) => Debug::fmt(slice, f),
+            F64(slice) => Debug::fmt(slice, f),
+        }
+    }
+}
+
+/// Mutable slice of the array contents
+pub enum ArraySliceMut<'a> {
+    /// Heterogeneous array containing mutable IValue objects
+    Heterogeneous(&'a mut [IValue]),
+    /// Typed array of mutable i8 values
+    I8(&'a mut [i8]),
+    /// Typed array of mutable u8 values
+    U8(&'a mut [u8]),
+    /// Typed array of mutable i16 values
+    I16(&'a mut [i16]),
+    /// Typed array of mutable u16 values
+    U16(&'a mut [u16]),
+    /// Typed array of mutable i32 values
+    I32(&'a mut [i32]),
+    /// Typed array of mutable u32 values
+    U32(&'a mut [u32]),
+    /// Typed array of mutable f32 values
+    F32(&'a mut [f32]),
+    /// Typed array of mutable i64 values
+    I64(&'a mut [i64]),
+    /// Typed array of mutable u64 values
+    U64(&'a mut [u64]),
+    /// Typed array of mutable f64 values
+    F64(&'a mut [f64]),
+}
+
 #[repr(C)]
 #[repr(align(8))]
 struct Header {
-    len: usize,
-    cap: usize,
+    /// Packed field:
+    /// bits 0-29: length,
+    /// bits 30-59: capacity,
+    /// bits 60-63: type tag
+    packed: u64,
+}
+
+impl Header {
+    const LEN_MASK: u64 = (1u64 << 30) - 1;
+    const LEN_SHIFT: u64 = 0;
+    const CAP_MASK: u64 = (1u64 << 30) - 1;
+    const CAP_SHIFT: u64 = 30;
+    const TAG_MASK: u64 = 0xF;
+    const TAG_SHIFT: u64 = 60;
+
+    const fn new(len: usize, cap: usize, tag: ArrayTag) -> Self {
+        assert!(len <= Self::LEN_MASK as usize, "Length exceeds 30-bit limit");
+        assert!(cap <= Self::CAP_MASK as usize, "Capacity exceeds 30-bit limit");
+
+        let packed = ((len as u64) & Self::LEN_MASK) << Self::LEN_SHIFT
+            | ((cap as u64) & Self::CAP_MASK) << Self::CAP_SHIFT
+            | ((tag as u64) & Self::TAG_MASK) << Self::TAG_SHIFT;
+
+        Self { packed }
+    }
+
+    fn len(&self) -> usize {
+        ((self.packed >> Self::LEN_SHIFT) & Self::LEN_MASK) as usize
+    }
+
+    fn cap(&self) -> usize {
+        ((self.packed >> Self::CAP_SHIFT) & Self::CAP_MASK) as usize
+    }
+
+    fn type_tag(&self) -> ArrayTag {
+        let tag_value = ((self.packed >> Self::TAG_SHIFT) & Self::TAG_MASK) as u8;
+        // Safety: We only store valid ArrayTag values
+        unsafe { std::mem::transmute(tag_value) }
+    }
+
+    fn set_len(&mut self, len: usize) {
+        assert!(len <= Self::LEN_MASK as usize, "Length exceeds 30-bit limit");
+        self.packed = (self.packed & !(Self::LEN_MASK << Self::LEN_SHIFT))
+            | (((len as u64) & Self::LEN_MASK) << Self::LEN_SHIFT);
+    }
+
+    fn set_cap(&mut self, cap: usize) {
+        assert!(cap <= Self::CAP_MASK as usize, "Capacity exceeds 30-bit limit");
+        self.packed = (self.packed & !(Self::CAP_MASK << Self::CAP_SHIFT))
+            | (((cap as u64) & Self::CAP_MASK) << Self::CAP_SHIFT);
+    }
+
 }
 
 trait HeaderRef<'a>: ThinRefExt<'a, Header> {
@@ -26,9 +298,26 @@ trait HeaderRef<'a>: ThinRefExt<'a, Header> {
         // Safety: pointers to the end of structs are allowed
         unsafe { self.ptr().add(1).cast::<IValue>() }
     }
-    fn items_slice(&self) -> &'a [IValue] {
+    fn raw_array_ptr(&self) -> *const u8 {
+        // Safety: pointers to the end of structs are allowed
+        unsafe { self.ptr().add(1).cast::<u8>() }
+    }
+    fn items_slice(&self) -> ArraySliceRef<'a> {
+        use ArraySliceRef::*;
         // Safety: Header `len` must be accurate
-        unsafe { std::slice::from_raw_parts(self.array_ptr(), self.len) }
+        match self.type_tag() {
+            ArrayTag::I8 => I8(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<i8>(), self.len()) }),
+            ArrayTag::U8 => U8(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<u8>(), self.len()) }),
+            ArrayTag::I16 => I16(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<i16>(), self.len()) }),
+            ArrayTag::U16 => U16(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<u16>(), self.len()) }),
+            ArrayTag::I32 => I32(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<i32>(), self.len()) }),
+            ArrayTag::U32 => U32(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<u32>(), self.len()) }),
+            ArrayTag::I64 => I64(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<i64>(), self.len()) }),
+            ArrayTag::U64 => U64(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<u64>(), self.len()) }),
+            ArrayTag::F32 => F32(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<f32>(), self.len()) }),
+            ArrayTag::F64 => F64(unsafe { std::slice::from_raw_parts(self.raw_array_ptr().cast::<f64>(), self.len()) }),
+            _ => Heterogeneous(unsafe { std::slice::from_raw_parts(self.array_ptr(), self.len()) }),
+        }
     }
 }
 
@@ -37,26 +326,63 @@ trait HeaderMut<'a>: ThinMutExt<'a, Header> {
         // Safety: pointers to the end of structs are allowed
         unsafe { self.ptr_mut().add(1).cast::<IValue>() }
     }
-    fn items_slice_mut(self) -> &'a mut [IValue] {
-        // Safety: Header `len` must be accurate
-        let len = self.len;
-        unsafe { std::slice::from_raw_parts_mut(self.array_ptr_mut(), len) }
+    fn raw_array_ptr_mut(mut self) -> *mut u8 {
+        // Safety: pointers to the end of structs are allowed
+        unsafe { self.ptr_mut().add(1).cast::<u8>() }
     }
+    fn items_slice_mut(self) -> ArraySliceMut<'a> {
+        use ArraySliceMut::*;
+        let len = self.len();
+        match self.type_tag() {
+            ArrayTag::I8 => I8(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<i8>(), len) }),
+            ArrayTag::U8 => U8(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<u8>(), len) }),
+            ArrayTag::I16 => I16(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<i16>(), len) }),
+            ArrayTag::U16 => U16(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<u16>(), len) }),
+            ArrayTag::I32 => I32(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<i32>(), len) }),
+            ArrayTag::U32 => U32(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<u32>(), len) }),
+            ArrayTag::I64 => I64(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<i64>(), len) }),
+            ArrayTag::U64 => U64(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<u64>(), len) }),
+            ArrayTag::F32 => F32(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<f32>(), len) }),
+            ArrayTag::F64 => F64(unsafe { std::slice::from_raw_parts_mut(self.raw_array_ptr_mut().cast::<f64>(), len) }),
+            _ => Heterogeneous(unsafe { std::slice::from_raw_parts_mut(self.array_ptr_mut(), len) }),
+        }
+    }
+
     // Safety: Space must already be allocated for the item
     unsafe fn push(&mut self, item: IValue) {
-        let index = self.len;
-        self.reborrow().array_ptr_mut().add(index).write(item);
-        self.len += 1;
+        use ArrayTag::*;
+        let index = self.len();
+        match self.type_tag() {
+            Heterogeneous => self.reborrow().array_ptr_mut().add(index).write(item),
+            _ => panic!("Can only push IValue items onto heterogeneous arrays"),
+        }
+        self.set_len(index + 1);
     }
     fn pop(&mut self) -> Option<IValue> {
-        if self.len == 0 {
+        if self.len() == 0 {
             None
         } else {
-            self.len -= 1;
-            let index = self.len;
+            use ArrayTag::*;
 
+            let new_len = self.len() - 1;
+            self.set_len(new_len);
+            let index = new_len;
+
+            let array_type = self.type_tag();
             // Safety: We just checked that an item exists
-            unsafe { Some(self.reborrow().array_ptr_mut().add(index).read()) }
+            match array_type {
+                Heterogeneous => Some(unsafe { self.reborrow().array_ptr_mut().add(index).read() }),
+                I8 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<i8>().add(index).read() }).map(IValue::from),
+                U8 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<u8>().add(index).read() }).map(IValue::from),
+                I16 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<i16>().add(index).read() }).map(IValue::from),
+                U16 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<u16>().add(index).read() }).map(IValue::from),
+                I32 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<i32>().add(index).read() }).map(IValue::from),
+                U32 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<u32>().add(index).read() }).map(IValue::from),
+                F32 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<f32>().add(index).read() }).map(IValue::from),
+                I64 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<i64>().add(index).read() }).map(IValue::from),
+                U64 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<u64>().add(index).read() }).map(IValue::from),
+                F64 => Some(unsafe { self.reborrow().raw_array_ptr_mut().cast::<f64>().add(index).read() }).map(IValue::from),
+            }
         }
     }
 }
@@ -100,37 +426,51 @@ pub struct IArray(pub(crate) IValue);
 
 value_subtype_impls!(IArray, into_array, as_array, as_array_mut);
 
-static EMPTY_HEADER: Header = Header { len: 0, cap: 0 };
+static EMPTY_HEADER: Header = Header::new(0, 0, ArrayTag::Heterogeneous);
+
+impl ArrayTag {
+    fn element_size(self) -> usize {
+        match self {
+            ArrayTag::Heterogeneous => std::mem::size_of::<IValue>(),
+            ArrayTag::I8 | ArrayTag::U8 => 1,
+            ArrayTag::I16 | ArrayTag::U16 => 2,
+            ArrayTag::I32 | ArrayTag::U32 | ArrayTag::F32 => 4,
+            ArrayTag::I64 | ArrayTag::U64 | ArrayTag::F64 => 8,
+        }
+    }
+}
 
 impl IArray {
-    fn layout(cap: usize) -> Result<Layout, LayoutError> {
+    fn layout(cap: usize, tag: ArrayTag) -> Result<Layout, LayoutError> {
         Ok(Layout::new::<Header>()
-            .extend(Layout::array::<usize>(cap)?)?
+            .extend(Layout::array::<u8>(cap * tag.element_size())?)?
             .0
             .pad_to_align())
     }
 
-    fn alloc(cap: usize) -> *mut Header {
+    fn alloc(cap: usize, tag: ArrayTag) -> *mut Header {
         unsafe {
-            let ptr = alloc(Self::layout(cap).unwrap()).cast::<Header>();
-            ptr.write(Header { len: 0, cap });
+            let ptr = alloc(Self::layout(cap, tag).unwrap()).cast::<Header>();
+            ptr.write(Header::new(0, cap, tag));
             ptr
         }
     }
 
     fn realloc(ptr: *mut Header, new_cap: usize) -> *mut Header {
         unsafe {
-            let old_layout = Self::layout((*ptr).cap).unwrap();
-            let new_layout = Self::layout(new_cap).unwrap();
+            let tag = (*ptr).type_tag();
+            let old_layout = Self::layout((*ptr).cap(), tag).unwrap();
+            let new_layout = Self::layout(new_cap, tag).unwrap();
             let ptr = realloc(ptr.cast::<u8>(), old_layout, new_layout.size()).cast::<Header>();
-            (*ptr).cap = new_cap;
+            (*ptr).set_cap(new_cap);
             ptr
         }
     }
 
     fn dealloc(ptr: *mut Header) {
         unsafe {
-            let layout = Self::layout((*ptr).cap).unwrap();
+            let tag = (*ptr).type_tag();
+            let layout = Self::layout((*ptr).cap(), tag).unwrap();
             dealloc(ptr.cast(), layout);
         }
     }
@@ -145,19 +485,25 @@ impl IArray {
     /// can be added to the array without reallocating.
     #[must_use]
     pub fn with_capacity(cap: usize) -> Self {
+        Self::with_capacity_and_tag(cap, ArrayTag::Heterogeneous)
+    }
+
+    /// Constructs a new `IArray` with the specified capacity and array type.
+    #[must_use]
+    fn with_capacity_and_tag(cap: usize, tag: ArrayTag) -> Self {
         if cap == 0 {
             Self::new()
         } else {
-            IArray(unsafe { IValue::new_ptr(Self::alloc(cap).cast(), TypeTag::ArrayOrFalse) })
+            IArray(unsafe { IValue::new_ptr(Self::alloc(cap, tag).cast(), TypeTag::ArrayOrFalse) })
         }
     }
 
-    fn header(&self) -> ThinRef<Header> {
+    fn header(&self) -> ThinRef<'_, Header> {
         unsafe { ThinRef::new(self.0.ptr().cast()) }
     }
 
     // Safety: must not be static
-    unsafe fn header_mut(&mut self) -> ThinMut<Header> {
+    unsafe fn header_mut(&mut self) -> ThinMut<'_, Header> {
         ThinMut::new(self.0.ptr().cast())
     }
 
@@ -168,14 +514,16 @@ impl IArray {
     /// can hold without reallocating.
     #[must_use]
     pub fn capacity(&self) -> usize {
-        self.header().cap
+        self.header().cap()
     }
 
     /// Returns the number of items currently stored in the array.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.header().len
+        self.header().len()
     }
+
+
 
     /// Returns `true` if the array is empty.
     #[must_use]
@@ -183,16 +531,16 @@ impl IArray {
         self.len() == 0
     }
 
-    /// Borrows a slice of [`IValue`]s from the array
+    /// Borrows a slice of the array contents
     #[must_use]
-    pub fn as_slice(&self) -> &[IValue] {
+    pub fn as_slice(&self) -> ArraySliceRef<'_> {
         self.header().items_slice()
     }
 
-    /// Borrows a mutable slice of [`IValue`]s from the array
-    pub fn as_mut_slice(&mut self) -> &mut [IValue] {
+    /// Borrows a mutable slice of the array contents
+    pub fn as_mut_slice(&mut self) -> ArraySliceMut<'_> {
         if self.is_static() {
-            &mut []
+            ArraySliceMut::Heterogeneous(&mut [])
         } else {
             unsafe { self.header_mut().items_slice_mut() }
         }
@@ -200,7 +548,12 @@ impl IArray {
 
     fn resize_internal(&mut self, cap: usize) {
         if self.is_static() || cap == 0 {
-            *self = Self::with_capacity(cap);
+            let tag = if self.is_static() {
+                ArrayTag::Heterogeneous
+            } else {
+                self.header().type_tag()
+            };
+            *self = Self::with_capacity_and_tag(cap, tag);
         } else {
             unsafe {
                 let new_ptr = Self::realloc(self.0.ptr().cast(), cap);
@@ -212,8 +565,8 @@ impl IArray {
     /// Reserves space for at least this many additional items.
     pub fn reserve(&mut self, additional: usize) {
         let hd = self.header();
-        let current_capacity = hd.cap;
-        let desired_capacity = hd.len.checked_add(additional).unwrap();
+        let current_capacity = hd.cap();
+        let desired_capacity = hd.len().checked_add(additional).unwrap();
         if current_capacity >= desired_capacity {
             return;
         }
@@ -228,8 +581,15 @@ impl IArray {
         }
         unsafe {
             let mut hd = self.header_mut();
-            while hd.len > len {
-                hd.pop();
+            if hd.type_tag() == ArrayTag::Heterogeneous {
+                while hd.len() > len {
+                    hd.pop();
+                }
+            } else {
+                // we don't need to drop primitives
+                if len < hd.len() {
+                    hd.set_len(len);
+                }
             }
         }
     }
@@ -249,12 +609,16 @@ impl IArray {
         unsafe {
             // Safety: cannot be static after calling `reserve`
             let mut hd = self.header_mut();
-            assert!(index <= hd.len);
+            assert!(index <= hd.len());
 
             // Safety: We just reserved enough space for at least one extra item
             hd.push(item.into());
-            if index < hd.len {
-                hd.items_slice_mut()[index..].rotate_right(1);
+            if index < hd.len() {
+                use ArraySliceMut::*;
+                match hd.reborrow().items_slice_mut() {
+                    Heterogeneous(slice) => slice[index..].rotate_right(1),
+                    _ => panic!("Can only push IValue items onto heterogeneous arrays"),
+                };
             }
         }
     }
@@ -271,8 +635,21 @@ impl IArray {
         if index < self.len() {
             // Safety: cannot be static if index <= len
             unsafe {
+                use ArraySliceMut::*;
                 let mut hd = self.header_mut();
-                hd.reborrow().items_slice_mut()[index..].rotate_left(1);
+                match hd.reborrow().items_slice_mut() {
+                    Heterogeneous(slice) => slice[index..].rotate_left(1),
+                    I8(slice) => slice[index..].rotate_left(1),
+                    U8(slice) => slice[index..].rotate_left(1),
+                    I16(slice) => slice[index..].rotate_left(1),
+                    U16(slice) => slice[index..].rotate_left(1),
+                    I32(slice) => slice[index..].rotate_left(1),
+                    U32(slice) => slice[index..].rotate_left(1),
+                    F32(slice) => slice[index..].rotate_left(1),
+                    I64(slice) => slice[index..].rotate_left(1),
+                    U64(slice) => slice[index..].rotate_left(1),
+                    F64(slice) => slice[index..].rotate_left(1),
+                };
                 hd.pop()
             }
         } else {
@@ -292,9 +669,22 @@ impl IArray {
         if index < self.len() {
             // Safety: cannot be static if index <= len
             unsafe {
+                use ArraySliceMut::*;
                 let mut hd = self.header_mut();
-                let last_index = hd.len - 1;
-                hd.reborrow().items_slice_mut().swap(index, last_index);
+                let last_index = hd.len() - 1;
+                match hd.reborrow().items_slice_mut() {
+                    Heterogeneous(slice) => slice.swap(index, last_index),
+                    I8(slice) => slice.swap(index, last_index),
+                    U8(slice) => slice.swap(index, last_index),
+                    I16(slice) => slice.swap(index, last_index),
+                    U16(slice) => slice.swap(index, last_index),
+                    I32(slice) => slice.swap(index, last_index),
+                    U32(slice) => slice.swap(index, last_index),
+                    F32(slice) => slice.swap(index, last_index),
+                    I64(slice) => slice.swap(index, last_index),
+                    U64(slice) => slice.swap(index, last_index),
+                    F64(slice) => slice.swap(index, last_index),
+                };
                 hd.pop()
             }
         } else {
@@ -322,6 +712,23 @@ impl IArray {
         }
     }
 
+    fn reverse(&mut self) {
+        use ArraySliceMut::*;
+        match self.as_mut_slice() {
+            Heterogeneous(slice) => slice.reverse(),
+            I8(slice) => slice.reverse(),
+            U8(slice) => slice.reverse(),
+            I16(slice) => slice.reverse(),
+            U16(slice) => slice.reverse(),
+            I32(slice) => slice.reverse(),
+            U32(slice) => slice.reverse(),
+            F32(slice) => slice.reverse(),
+            I64(slice) => slice.reverse(),
+            U64(slice) => slice.reverse(),
+            F64(slice) => slice.reverse(),
+        }
+    }
+
     /// Shrinks the memory allocation used by the array such that its
     /// capacity becomes equal to its length.
     pub fn shrink_to_fit(&mut self) {
@@ -329,17 +736,38 @@ impl IArray {
     }
 
     pub(crate) fn clone_impl(&self) -> IValue {
-        let src = self.header().items_slice();
-        let l = src.len();
-        let mut res = Self::with_capacity(l);
+        let hd = self.header();
+        let len = hd.len();
+        let tag = hd.type_tag();
 
-        if l > 0 {
-            unsafe {
-                // Safety: we cannot be static if len > 0
-                let mut hd = res.header_mut();
-                for v in src {
-                    // Safety: we reserved enough space at the start
-                    hd.push(v.clone());
+        // Preserve the original capacity, not just the length
+        let mut res = Self::with_capacity_and_tag(len, tag);
+
+        if len > 0 {
+            if tag == ArrayTag::Heterogeneous {
+                // For heterogeneous arrays, clone IValue objects
+                let ArraySliceRef::Heterogeneous(src) = hd.items_slice() else {
+                    unreachable!()
+                };
+                unsafe {
+                    // Safety: we cannot be static if len > 0
+                    let mut res_hd = res.header_mut();
+                    for v in src {
+                        // Safety: we reserved enough space at the start
+                        res_hd.push(v.clone());
+                    }
+                }
+            } else {
+                // For typed arrays, copy raw primitive data
+                unsafe {
+                    let src_ptr = hd.raw_array_ptr();
+                    let dst_ptr = res.header_mut().raw_array_ptr_mut();
+                    let element_size = tag.element_size();
+                    let total_bytes = len * element_size;
+                    std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, total_bytes);
+
+                    // Update the length
+                    res.header_mut().set_len(len);
                 }
             }
         }
@@ -359,8 +787,15 @@ impl IArray {
         if self.is_static() {
             0
         } else {
-            Self::layout(self.capacity()).unwrap().size()
-                + self.iter().map(IValue::mem_allocated).sum::<usize>()
+            let tag = self.header().type_tag();
+            let layout_size = Self::layout(self.capacity(), tag).unwrap().size();
+            if let ArraySliceRef::Heterogeneous(slice) = self.as_slice() {
+                // For heterogeneous arrays, include memory allocated by contained IValue objects
+                layout_size + slice.iter().map(IValue::mem_allocated).sum::<usize>()
+            } else {
+                // For typed arrays, just return the layout size since primitives don't allocate additional memory
+                layout_size
+            }
         }
     }
 }
@@ -370,17 +805,25 @@ impl<A: DefragAllocator> Defrag<A> for IArray {
         if self.is_static() {
             return self;
         }
-        for i in 0..self.len() {
-            unsafe {
-                let val = self.as_ptr().add(i).read();
-                let val = val.defrag(defrag_allocator);
-                std::ptr::write(self.as_ptr().add(i) as *mut IValue, val);
+        match self.as_mut_slice() {
+            ArraySliceMut::Heterogeneous(slice) => {
+                for i in 0..slice.len() {
+                    unsafe {
+                        let val = slice.as_ptr().add(i).read();
+                        let val = val.defrag(defrag_allocator);
+                        std::ptr::write(slice.as_ptr().add(i) as *mut IValue, val);
+                    }
+                }
             }
+            _ => {}, // typed arrays don't need defragmentation
         }
+        
         unsafe {
+            let header = &*self.0.ptr().cast::<Header>();
+            let tag = header.type_tag();
             let new_ptr = defrag_allocator.realloc_ptr(
                 self.0.ptr(),
-                Self::layout((*self.0.ptr().cast::<Header>()).cap)
+                Self::layout(header.cap(), tag)
                     .expect("layout is expected to return a valid value"),
             );
             self.0.set_ptr(new_ptr.cast());
@@ -401,40 +844,88 @@ impl IntoIterator for IArray {
     }
 }
 
-impl Deref for IArray {
-    type Target = [IValue];
+// impl Deref for IArray {
+//     type Target = [IValue];
 
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
+//     fn deref(&self) -> &Self::Target {
+//         self.as_slice()
+//     }
+// }
 
-impl DerefMut for IArray {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut_slice()
-    }
-}
+// impl DerefMut for IArray {
+//     fn deref_mut(&mut self) -> &mut Self::Target {
+//         self.as_mut_slice()
+//     }
+// }
 
-impl Borrow<[IValue]> for IArray {
-    fn borrow(&self) -> &[IValue] {
-        self.as_slice()
-    }
-}
+// impl Borrow<[IValue]> for IArray {
+//     fn borrow(&self) -> &[IValue] {
+//         self.as_slice()
+//     }
+// }
 
-impl BorrowMut<[IValue]> for IArray {
-    fn borrow_mut(&mut self) -> &mut [IValue] {
-        self.as_mut_slice()
-    }
-}
+// impl BorrowMut<[IValue]> for IArray {
+//     fn borrow_mut(&mut self) -> &mut [IValue] {
+//         self.as_mut_slice()
+//     }
+// }
 
 impl Hash for IArray {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_slice().hash(state);
+        use ArraySliceRef::*;
+        match self.as_slice() {
+            Heterogeneous(slice) => slice.hash(state),
+            I8(slice) => slice.hash(state),
+            U8(slice) => slice.hash(state),
+            I16(slice) => slice.hash(state),
+            U16(slice) => slice.hash(state),
+            I32(slice) => slice.hash(state),
+            U32(slice) => slice.hash(state),
+            I64(slice) => slice.hash(state),
+            U64(slice) => slice.hash(state),
+            F32(slice) => slice.iter().map(|f| IValue::from(*f)).collect::<Vec<_>>().hash(state),
+            F64(slice) => slice.iter().map(|f| IValue::from(*f)).collect::<Vec<_>>().hash(state),
+        }
     }
 }
 
+macro_rules! extend_impl {
+    ($($ty:ty),*) => {
+        $(impl Extend<$ty> for IArray {
+            fn extend<T: IntoIterator<Item = $ty>>(&mut self, iter: T) {
+                let expected_tag = ArrayTag::from_type::<$ty>();
+                let actual_tag = self.header().type_tag();
+                if actual_tag != expected_tag {
+                    panic!("Type tag mismatch, expected {:?} but found {:?}", expected_tag, actual_tag);
+                }
+                let iter = iter.into_iter();
+                self.reserve(iter.size_hint().0);
+
+                // For typed arrays, store raw primitive values directly
+                unsafe {
+                    let start_index = self.header().len();
+                    let hd = self.header_mut();
+                    let array_ptr = hd.raw_array_ptr_mut().cast::<$ty>();
+                    let mut index = start_index;
+
+                    for v in iter {
+                        array_ptr.add(index).write(v);
+                        index += 1;
+                    }
+
+                    // Update length after writing all values
+                    let mut hd = self.header_mut();
+                    hd.set_len(index);
+                }
+            }
+        })*
+    };
+}
+
+extend_impl!(i8, i16, i32, i64, u8, u16, u32, u64, f32, f64);
+
 impl<U: Into<IValue>> Extend<U> for IArray {
-    fn extend<T: IntoIterator<Item = U>>(&mut self, iter: T) {
+    default fn extend<T: IntoIterator<Item = U>>(&mut self, iter: T) {
         let iter = iter.into_iter();
         self.reserve(iter.size_hint().0);
         for v in iter {
@@ -444,25 +935,56 @@ impl<U: Into<IValue>> Extend<U> for IArray {
 }
 
 impl<U: Into<IValue>> FromIterator<U> for IArray {
-    fn from_iter<T: IntoIterator<Item = U>>(iter: T) -> Self {
+    default fn from_iter<T: IntoIterator<Item = U>>(iter: T) -> Self {
         let mut res = IArray::new();
         res.extend(iter);
         res
     }
 }
 
-impl AsRef<[IValue]> for IArray {
-    fn as_ref(&self) -> &[IValue] {
-        self.as_slice()
-    }
+macro_rules! from_iter_impl {
+    ($($ty:ty),*) => {
+        $(impl FromIterator<$ty> for IArray {
+            fn from_iter<T: IntoIterator<Item = $ty>>(iter: T) -> Self {
+                let iter = iter.into_iter();
+                let mut res = IArray::with_capacity_and_tag(iter.size_hint().0, ArrayTag::from_type::<$ty>());
+                res.extend(iter);
+                res
+            }
+        })*
+    };
 }
+
+from_iter_impl!(i8, i16, i32, i64, u8, u16, u32, u64, f32, f64);
+
+// impl AsRef<[IValue]> for IArray {
+//     fn as_ref(&self) -> &[IValue] {
+//         self.as_slice()
+//     }
+// }
 
 impl PartialEq for IArray {
     fn eq(&self, other: &Self) -> bool {
         if self.0.raw_eq(&other.0) {
             true
+        } else if self.header().type_tag() != other.header().type_tag() {
+            false
         } else {
-            self.as_slice() == other.as_slice()
+            use ArraySliceRef::*;
+            match (self.as_slice(), other.as_slice()) {
+                (Heterogeneous(a), Heterogeneous(b)) => a == b,
+                (I8(a), I8(b)) => a == b,
+                (U8(a), U8(b)) => a == b,
+                (I16(a), I16(b)) => a == b,
+                (U16(a), U16(b)) => a == b,
+                (I32(a), I32(b)) => a == b,
+                (U32(a), U32(b)) => a == b,
+                (F32(a), F32(b)) => a == b,
+                (I64(a), I64(b)) => a == b,
+                (U64(a), U64(b)) => a == b,
+                (F64(a), F64(b)) => a == b,
+                _ => false, // Different types should never reach here due to the type_tag check above
+            }
         }
     }
 }
@@ -473,7 +995,7 @@ impl PartialOrd for IArray {
         if self.0.raw_eq(&other.0) {
             Some(Ordering::Equal)
         } else {
-            self.as_slice().partial_cmp(other.as_slice())
+            self.as_slice().partial_cmp(&other.as_slice())
         }
     }
 }
@@ -483,33 +1005,67 @@ impl<I: SliceIndex<[IValue]>> Index<I> for IArray {
 
     #[inline]
     fn index(&self, index: I) -> &Self::Output {
-        Index::index(self.as_slice(), index)
+        match self.as_slice() {
+            ArraySliceRef::Heterogeneous(slice) => Index::index(slice, index),
+            _ => panic!("Invalid index access"),
+        }
     }
 }
 
 impl<I: SliceIndex<[IValue]>> IndexMut<I> for IArray {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
-        IndexMut::index_mut(self.as_mut_slice(), index)
+        match self.as_mut_slice() {
+            ArraySliceMut::Heterogeneous(slice) => IndexMut::index_mut(slice, index),
+            _ => panic!("Invalid index access"),
+        }
     }
 }
 
 impl Debug for IArray {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Debug::fmt(self.as_slice(), f)
+        self.as_slice().fmt(f)
     }
 }
 
+macro_rules! from_vec_impl {
+    ($($ty:ty),*) => {
+        $(impl From<Vec<$ty>> for IArray {
+            fn from(other: Vec<$ty>) -> Self {
+                let mut res = IArray::with_capacity_and_tag(other.len(), ArrayTag::from_type::<$ty>());
+                res.extend(other.into_iter());
+                res
+            }
+        })*
+    };
+}
+
+from_vec_impl!(i8, i16, i32, i64, u8, u16, u32, u64, f32, f64);
+
 impl<T: Into<IValue>> From<Vec<T>> for IArray {
-    fn from(other: Vec<T>) -> Self {
+    default fn from(other: Vec<T>) -> Self {
         let mut res = IArray::with_capacity(other.len());
         res.extend(other.into_iter().map(Into::into));
         res
     }
 }
 
+macro_rules! from_slice_impl {
+    ($($ty:ty),*) => {
+        $(impl From<&[$ty]> for IArray {
+            fn from(other: &[$ty]) -> Self {
+                let mut res = IArray::with_capacity_and_tag(other.len(), ArrayTag::from_type::<$ty>());
+                res.extend(other.iter().cloned());
+                res
+            }
+        })*
+    };
+}
+
+from_slice_impl!(i8, i16, i32, i64, u8, u16, u32, u64, f32, f64);
+
 impl<T: Into<IValue> + Clone> From<&[T]> for IArray {
-    fn from(other: &[T]) -> Self {
+    default fn from(other: &[T]) -> Self {
         let mut res = IArray::with_capacity(other.len());
         res.extend(other.iter().cloned().map(Into::into));
         res
@@ -544,6 +1100,95 @@ impl Default for IArray {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_from_vec_memory_safety() {
+        // Test the from_vec implementation for memory safety
+        println!("Creating i32 vec");
+        let vec_i32 = vec![1i32, 2, 3, 4, 5];
+        println!("Converting to IArray");
+        let arr = IArray::from(vec_i32);
+        println!("Checking length: {}", arr.len());
+        assert_eq!(arr.len(), 5);
+        println!("Checking type tag: {:?}", arr.header().type_tag());
+        assert_eq!(arr.header().type_tag(), ArrayTag::I32);
+        println!("i32 array test passed");
+
+        // Test drop by letting arr go out of scope
+        drop(arr);
+        println!("Drop completed successfully");
+
+        // Test other types
+        let vec_f64 = vec![1.0f64, 2.0, 3.0];
+        let arr2 = IArray::from(vec_f64);
+        assert_eq!(arr2.len(), 3);
+        assert_eq!(arr2.header().type_tag(), ArrayTag::F64);
+
+        let vec_u8 = vec![1u8, 2, 3];
+        let arr3 = IArray::from(vec_u8);
+        assert_eq!(arr3.len(), 3);
+        assert_eq!(arr3.header().type_tag(), ArrayTag::U8);
+
+        println!("All typed array tests passed");
+    }
+
+    #[test]
+    fn test_header_packing() {
+        // Test that the header correctly packs and unpacks values
+        let header = Header::new(123, 456, ArrayTag::I32);
+        assert_eq!(header.len(), 123);
+        assert_eq!(header.cap(), 456);
+        assert_eq!(header.type_tag(), ArrayTag::I32);
+
+        // Test maximum values (30 bits = 1,073,741,823)
+        let max_30_bit = (1usize << 30) - 1;
+        let header_max = Header::new(max_30_bit, max_30_bit, ArrayTag::F64);
+        assert_eq!(header_max.len(), max_30_bit);
+        assert_eq!(header_max.cap(), max_30_bit);
+        assert_eq!(header_max.type_tag(), ArrayTag::F64);
+
+        // Test that the header is 64 bits (8 bytes)
+        assert_eq!(std::mem::size_of::<Header>(), 8);
+    }
+
+    #[test]
+    fn test_typed_slice() {
+        // Test heterogeneous array
+        let hetero_array: IArray = vec![IValue::NULL, IValue::TRUE, IValue::FALSE].into();
+        match hetero_array.as_slice() {
+            ArraySliceRef::Heterogeneous(slice) => {
+                assert_eq!(slice.len(), 3);
+                assert_eq!(slice[0], IValue::NULL);
+                assert_eq!(slice[1], IValue::TRUE);
+                assert_eq!(slice[2], IValue::FALSE);
+            }
+            _ => panic!("Expected heterogeneous slice"),
+        }
+
+        // Test typed i32 array
+        let i32_array: IArray = vec![1i32, 2i32, 3i32].into();
+        match i32_array.as_slice() {
+            ArraySliceRef::I32(slice) => {
+                assert_eq!(slice.len(), 3);
+                assert_eq!(slice[0], 1);
+                assert_eq!(slice[1], 2);
+                assert_eq!(slice[2], 3);
+            }
+            _ => panic!("Expected i32 slice"),
+        }
+
+        // Test typed f64 array
+        let f64_array: IArray = vec![1.0f64, 2.5f64, 3.14f64].into();
+        match f64_array.as_slice() {
+            ArraySliceRef::F64(slice) => {
+                assert_eq!(slice.len(), 3);
+                assert_eq!(slice[0], 1.0);
+                assert_eq!(slice[1], 2.5);
+                assert_eq!(slice[2], 3.14);
+            }
+            _ => panic!("Expected f64 slice"),
+        }
+    }
+
     #[mockalloc::test]
     fn can_create() {
         let x = IArray::new();
@@ -557,7 +1202,7 @@ mod tests {
         let x = vec![IValue::NULL, IValue::TRUE, IValue::FALSE];
         let y: IArray = x.iter().cloned().collect();
 
-        assert_eq!(x.as_slice(), y.as_slice());
+        assert_eq!(y.as_slice(), x.as_slice().into());
     }
 
     #[mockalloc::test]
@@ -567,7 +1212,7 @@ mod tests {
         x.push(IValue::TRUE);
         x.insert(1, IValue::FALSE);
 
-        assert_eq!(x.as_slice(), &[IValue::NULL, IValue::FALSE, IValue::TRUE]);
+        assert_eq!(x.as_slice(), [IValue::NULL, IValue::FALSE, IValue::TRUE].as_slice().into());
     }
 
     #[mockalloc::test]
@@ -590,7 +1235,7 @@ mod tests {
         assert_eq!(x.remove(1), Some(IValue::TRUE));
         assert_eq!(x.pop(), Some(IValue::FALSE));
 
-        assert_eq!(x.as_slice(), &[IValue::NULL]);
+        assert_eq!(x.as_slice(), [IValue::NULL].as_slice().into());
     }
 
     #[mockalloc::test]
@@ -598,7 +1243,7 @@ mod tests {
         let mut x: IArray = vec![IValue::NULL, IValue::TRUE, IValue::FALSE].into();
         assert_eq!(x.swap_remove(0), Some(IValue::NULL));
 
-        assert_eq!(x.as_slice(), &[IValue::FALSE, IValue::TRUE]);
+        assert_eq!(x.as_slice(), [IValue::FALSE, IValue::TRUE].as_slice().into());
     }
 
     #[mockalloc::test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::fmt::{self, Formatter};
 
 use serde::de::{
-    self, DeserializeSeed, EnumAccess, Error as SError, Expected, IntoDeserializer, MapAccess, SeqAccess, Unexpected, VariantAccess, Visitor
+    DeserializeSeed, EnumAccess, Error as SError, Expected, IntoDeserializer, MapAccess, SeqAccess, Unexpected, VariantAccess, Visitor
 };
 use serde::{forward_to_deserialize_any, Deserialize, Deserializer};
 use serde_json::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //!   There is no performance benefit to this, but it can help avoid false positives
 //!   from tools like `mockalloc` which try to detect memory leaks during tests.
 #![deny(missing_docs, missing_debug_implementations)]
+#![feature(min_specialization)]
 
 #[macro_use]
 mod macros;

--- a/src/number.rs
+++ b/src/number.rs
@@ -272,6 +272,26 @@ impl INumber {
     pub fn to_usize(&self) -> Option<usize> {
         self.to_u64().map(|v| v as _)
     }
+    /// Converts this number to an i8 if it can be represented exactly.
+    #[must_use]
+    pub fn to_i8(&self) -> Option<i8> {
+        self.to_i64().and_then(|x| x.try_into().ok())
+    }
+    /// Converts this number to a u8 if it can be represented exactly.
+    #[must_use]
+    pub fn to_u8(&self) -> Option<u8> {
+        self.to_u64().and_then(|x| x.try_into().ok())
+    }
+    /// Converts this number to an i16 if it can be represented exactly.
+    #[must_use]
+    pub fn to_i16(&self) -> Option<i16> {
+        self.to_i64().and_then(|x| x.try_into().ok())
+    }
+    /// Converts this number to a u16 if it can be represented exactly.
+    #[must_use]
+    pub fn to_u16(&self) -> Option<u16> {
+        self.to_u64().and_then(|x| x.try_into().ok())
+    }
     /// Converts this number to an i32 if it can be represented exactly.
     #[must_use]
     pub fn to_i32(&self) -> Option<i32> {

--- a/src/object.rs
+++ b/src/object.rs
@@ -108,7 +108,7 @@ struct SplitHeaderMut<'a> {
 }
 
 impl<'a> SplitHeaderMut<'a> {
-    fn as_ref(&self) -> SplitHeader {
+    fn as_ref(&self) -> SplitHeader<'_> {
         SplitHeader {
             cap: self.cap,
             items: self.items,
@@ -570,12 +570,12 @@ impl IObject {
         }
     }
 
-    fn header(&self) -> ThinRef<Header> {
+    fn header(&self) -> ThinRef<'_, Header> {
         unsafe { ThinRef::new(self.0.ptr().cast()) }
     }
 
     // Safety: must not be static
-    unsafe fn header_mut(&mut self) -> ThinMut<Header> {
+    unsafe fn header_mut(&mut self) -> ThinMut<'_, Header> {
         ThinMut::new(self.0.ptr().cast())
     }
 
@@ -626,14 +626,14 @@ impl IObject {
     }
 
     /// Returns a view of an entry within this object.
-    pub fn entry(&mut self, key: impl Into<IString>) -> Entry {
+    pub fn entry(&mut self, key: impl Into<IString>) -> Entry<'_> {
         self.reserve(1);
         // Safety: cannot be static after reserving space
         unsafe { self.header_mut().entry(key.into()) }
     }
     /// Returns a view of an entry within this object, whilst avoiding
     /// cloning the key if the entry is already occupied.
-    pub fn entry_or_clone(&mut self, key: &IString) -> Entry {
+    pub fn entry_or_clone(&mut self, key: &IString) -> Entry<'_> {
         self.reserve(1);
         // Safety: cannot be static after reserving space
         unsafe { self.header_mut().entry_or_clone(key) }
@@ -648,7 +648,7 @@ impl IObject {
     }
     /// Returns an iterator over (&key, &value) pairs in this object.
     #[must_use]
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter(self.header().split().items.iter())
     }
     /// Returns an iterator over mutable references to the values in
@@ -657,7 +657,7 @@ impl IObject {
         self.iter_mut().map(|x| x.1)
     }
     /// Returns an iterator over (&key, &mut value) pairs in this object.
-    pub fn iter_mut(&mut self) -> IterMut {
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
         IterMut(
             if self.is_empty() {
                 &mut []

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -64,7 +64,7 @@ impl Serialize for IArray {
     {
         let mut s = serializer.serialize_seq(Some(self.len()))?;
         for v in self {
-            s.serialize_element(v)?;
+            s.serialize_element(&v)?;
         }
         s.end()
     }

--- a/src/thin.rs
+++ b/src/thin.rs
@@ -69,7 +69,7 @@ pub trait ThinRefExt<'a, T>: Deref<Target = T> {
 
 pub trait ThinMutExt<'a, T>: DerefMut<Target = T> + ThinRefExt<'a, T> + Sized {
     fn ptr_mut(&mut self) -> *mut T;
-    fn reborrow(&mut self) -> ThinMut<T>;
+    fn reborrow(&mut self) -> ThinMut<'_, T>;
 }
 
 impl<'a, T> ThinRefExt<'a, T> for ThinRef<'a, T> {
@@ -88,7 +88,7 @@ impl<'a, T> ThinMutExt<'a, T> for ThinMut<'a, T> {
     fn ptr_mut(&mut self) -> *mut T {
         self.ptr.as_ptr()
     }
-    fn reborrow(&mut self) -> ThinMut<T> {
+    fn reborrow(&mut self) -> ThinMut<'_, T> {
         Self {
             ptr: self.ptr,
             phantom: self.phantom,

--- a/src/unsafe_string.rs
+++ b/src/unsafe_string.rs
@@ -183,7 +183,7 @@ impl Borrow<str> for WeakIString {
     }
 }
 impl WeakIString {
-    fn header(&self) -> ThinMut<Header> {
+    fn header(&self) -> ThinMut<'_, Header> {
         // Safety: pointer is always valid
         unsafe { ThinMut::new(self.ptr.as_ptr()) }
     }
@@ -282,7 +282,7 @@ impl IString {
         Self::intern_with_allocator(s, |layout| unsafe { alloc(layout) })
     }
 
-    fn header(&self) -> ThinMut<Header> {
+    fn header(&self) -> ThinMut<'_, Header> {
         unsafe { ThinMut::new(self.0.ptr().cast()) }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -551,6 +551,26 @@ impl IValue {
     pub fn to_f32(&self) -> Option<f32> {
         self.as_number()?.to_f32()
     }
+    /// Converts this value to an i8 if it is a number that can be represented exactly.
+    #[must_use]
+    pub fn to_i8(&self) -> Option<i8> {
+        self.as_number()?.to_i8()
+    }
+    /// Converts this value to a u8 if it is a number that can be represented exactly.
+    #[must_use]
+    pub fn to_u8(&self) -> Option<u8> {
+        self.as_number()?.to_u8()
+    }
+    /// Converts this value to an i16 if it is a number that can be represented exactly.
+    #[must_use]
+    pub fn to_i16(&self) -> Option<i16> {
+        self.as_number()?.to_i16()
+    }
+    /// Converts this value to a u16 if it is a number that can be represented exactly.
+    #[must_use]
+    pub fn to_u16(&self) -> Option<u16> {
+        self.as_number()?.to_u16()
+    }
     /// Converts this value to an i32 if it is a number that can be represented exactly.
     #[must_use]
     pub fn to_i32(&self) -> Option<i32> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 use std::mem;
 use std::ops::{Deref, Index, IndexMut};
 use std::ptr::NonNull;
+use half::{bf16, f16};
 
 use crate::{Defrag, DefragAllocator};
 
@@ -551,6 +552,16 @@ impl IValue {
     pub fn to_f32(&self) -> Option<f32> {
         self.as_number()?.to_f32()
     }
+    /// Converts this value to an f16 if it is a number that can be represented exactly.
+    #[must_use]
+    pub fn to_f16(&self) -> Option<f16> {
+        self.as_number()?.to_f16()
+    }
+    /// Converts this value to a bf16 if it is a number that can be represented exactly.
+    #[must_use]
+    pub fn to_bf16(&self) -> Option<bf16> {
+        self.as_number()?.to_bf16()
+    }
     /// Converts this value to an i8 if it is a number that can be represented exactly.
     #[must_use]
     pub fn to_i8(&self) -> Option<i8> {
@@ -602,6 +613,18 @@ impl IValue {
     #[must_use]
     pub fn to_f32_lossy(&self) -> Option<f32> {
         Some(self.as_number()?.to_f32_lossy())
+    }
+    /// Converts this value to an f16 if it is a number, potentially losing precision
+    /// in the process.
+    #[must_use]
+    pub fn to_f16_lossy(&self) -> Option<f16> {
+        Some(self.as_number()?.to_f16_lossy())
+    }
+    /// Converts this value to an bf16 if it is a number, potentially losing precision
+    /// in the process.
+    #[must_use]
+    pub fn to_bf16_lossy(&self) -> Option<bf16> {
+        Some(self.as_number()?.to_bf16_lossy())
     }
 
     // # String methods
@@ -1020,6 +1043,18 @@ typed_conversions! {
     IObject:
         HashMap<K, V> where (K: Into<IString>, V: Into<IValue>),
         BTreeMap<K, V> where (K: Into<IString>, V: Into<IValue>);
+}
+
+impl From<f16> for IValue {
+    fn from(v: f16) -> Self {
+        INumber::try_from(v).map(Into::into).unwrap_or(IValue::NULL)
+    }
+}
+
+impl From<bf16> for IValue {
+    fn from(v: bf16) -> Self {
+        INumber::try_from(v).map(Into::into).unwrap_or(IValue::NULL)
+    }
 }
 
 impl From<f32> for IValue {


### PR DESCRIPTION
TODO:
- ~add half::{f16, bf16} support~
- ~implicit type detection~
- ~optimize typed array deserialization, avoid IValue conversion overhead~
- ~`push_typed!` panics if conversion fails, this should be unreachable~
- ~hashing performance for floats~
- add unsafe direct slice access
- improve error handling. replace panics with Result/Option
- Tighten promotion/destructuring invariants
- Ensure serde round-trip coverage and iterator/slice ergonomics for all tags
- Document and enforce header size limits (30‑bit len/cap) and behavior on overflow
- Add comprehensive tests (esp. mixed-type `extend`/`insert`, defrag, drop, hashing, f16/bf16)
